### PR TITLE
Use int32 for Player/Client IDs

### DIFF
--- a/02_root_message_types/01_joingame.md
+++ b/02_root_message_types/01_joingame.md
@@ -60,8 +60,8 @@ This message is sent from the server to all clients in a game when another clien
 | Type | Name | Description |
 | --- | --- | --- |
 | `int32` | Game ID | The ID ([code](../07_miscellaneous/02_converting_game_ids_to_and_from_game_codes.md)) of the game |
-| `uint32` | Joining Client ID | The ID of the joining client |
-| `uint32` | Host Client ID | The ID of the client that is the current host of the game |
+| `int32` | Joining Client ID | The ID of the joining client |
+| `int32` | Host Client ID | The ID of the client that is the current host of the game |
 
 <details>
     <summary>Click here to view an example success packet</summary>

--- a/02_root_message_types/06_gamedatato.md
+++ b/02_root_message_types/06_gamedatato.md
@@ -5,7 +5,7 @@ Every `GameDataTo` message starts out with the same data, outlined in the table 
 | Type | Name | Description |
 | --- | --- | --- |
 | `int32` | Game ID | The ID ([code](../07_miscellaneous/02_converting_game_ids_to_and_from_game_codes.md)) of the game |
-| `packed uint32` | Target Client ID | The ID of the client that the message is being sent to |
+| `packed int32` | Target Client ID | The ID of the client that the message is being sent to |
 
 See [`GameData` and `GameDataTo` Message Types](../03_gamedata_and_gamedatato_message_types/README.md) for details on each possible message that may be contained in this message type, taking note that the data described in the table above is omitted from the breakdown of those messages.
 

--- a/02_root_message_types/07_joinedgame.md
+++ b/02_root_message_types/07_joinedgame.md
@@ -7,10 +7,10 @@ This message is sent from the host of a game to a client after the client has su
 | Type | Name | Description |
 | --- | --- | --- |
 | `int32` | Game ID | The ID ([code](../07_miscellaneous/02_converting_game_ids_to_and_from_game_codes.md)) of the game |
-| `uint32` | Joined Client ID | The ID of the client that joined the game |
-| `uint32` | Host Client ID | The ID of the client that is the current host of the game |
-| `packed uint32` | Other Client IDs Length | The number of clients in the game excluding the client that just joined |
-| `packed uint32[n]` | Other Client IDs | A list of the IDs of every other client in the game, where length `n` is defined in the previous field |
+| `int32` | Joined Client ID | The ID of the client that joined the game |
+| `int32` | Host Client ID | The ID of the client that is the current host of the game |
+| `packed int32` | Other Client IDs Length | The number of clients in the game excluding the client that just joined |
+| `packed int32[n]` | Other Client IDs | A list of the IDs of every other client in the game, where length `n` is defined in the previous field |
 
 <details>
     <summary>Click here to view an example packet</summary>

--- a/02_root_message_types/11_kickplayer.md
+++ b/02_root_message_types/11_kickplayer.md
@@ -7,7 +7,7 @@ This message is sent from the host of a game to all clients when the host kicks 
 | Type | Name | Description |
 | --- | --- | --- |
 | `int32` | Game ID | The ID ([code](../07_miscellaneous/02_converting_game_ids_to_and_from_game_codes.md)) of the game |
-| `packed uint32` | Kicked Client ID | The ID of the client that was kicked |
+| `packed int32` | Kicked Client ID | The ID of the client that was kicked |
 | `boolean` | Is Banned | Whether or not the client was also banned |
 | `byte` (*Optional*) | Disconnect Reason | The ID of the [disconnect reason](../01_packet_structure/06_enums.md#disconnectreason) for why the client was kicked |
 

--- a/02_root_message_types/12_waitforhost.md
+++ b/02_root_message_types/12_waitforhost.md
@@ -7,7 +7,7 @@ This message is sent from the host of a game that has just finished to a client 
 | Type | Name | Description |
 | --- | --- | --- |
 | `int32` | Game ID | The ID ([code](../07_miscellaneous/02_converting_game_ids_to_and_from_game_codes.md)) of the game |
-| `uint32` | Rejoining Client ID | The ID of the client that is rejoining the game |
+| `int32` | Rejoining Client ID | The ID of the client that is rejoining the game |
 
 <details>
     <summary>Click here to view an example packet</summary>

--- a/03_gamedata_and_gamedatato_message_types/06_scenechange.md
+++ b/03_gamedata_and_gamedatato_message_types/06_scenechange.md
@@ -6,7 +6,7 @@ This message is sent by the client to the host of a game when changing the game 
 
 | Type | Name | Description |
 | --- | --- | --- |
-| `packed uint32` | Client ID | The ID of the client that is changing scenes |
+| `packed int32` | Client ID | The ID of the client that is changing scenes |
 | `String` | Scene Name | The name of the scene that the client is changing to |
 
 <details>

--- a/03_gamedata_and_gamedatato_message_types/07_ready.md
+++ b/03_gamedata_and_gamedatato_message_types/07_ready.md
@@ -6,7 +6,7 @@ This message is sent by the client to the host of a game as a response to the [`
 
 | Type | Name | Description |
 | --- | --- | --- |
-| `packed uint32` | Ready Client ID | The ID of the client that is ready |
+| `packed int32` | Ready Client ID | The ID of the client that is ready |
 
 <details>
     <summary>Click here to view an example packet</summary>


### PR DESCRIPTION
The game uses int32 instead of uint32 for parsing any packet which uses client/player IDs.
![Screenshot of Among Us code that proves this](https://user-images.githubusercontent.com/32604996/112736036-459e0080-8f15-11eb-8597-389119d93808.png)

